### PR TITLE
documentation error: changed from nodechat.docpad to canvas.docpad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built using Socket.io, DocPad, Backbone.js and Twitter Bootstrap
 
 	``` bash
 	git clone git://github.com/balupton/canvas.docpad.git
-	cd nodechat.docpad
+	cd canvas.docpad
 	npm install
 	node script.js
 	```


### PR DESCRIPTION
hey,

It looks good. It is running find but not able to run the chat part :)

in console it is always printing asd .. I will check.
